### PR TITLE
Update linux-x64-deb.yml to Enable WebGL

### DIFF
--- a/.github/workflows/linux-x64-deb.yml
+++ b/.github/workflows/linux-x64-deb.yml
@@ -74,7 +74,7 @@ jobs:
         cd DEBIAN
         chmod +x postinst postrm preinst prerm
         cd ../usr/lib/floorp
-        chmod +x floorp floorp-bin floorp.sh lib*.so plugin-container gmp-clearkey/0.1/libclearkey.so
+        chmod +x floorp floorp-bin glxtest vaapitest floorp.sh lib*.so plugin-container gmp-clearkey/0.1/libclearkey.so
         sudo chown -R root:root $DEBWORK
         cd $WORKDIR
         sudo dpkg-deb -b $DEBWORK


### PR DESCRIPTION
Giving execute permissions to GLXTest and VAAPITest to enable WebGL in Linux. (This will only affect .deb)

---

<!-- Please enter details on below this line -->
